### PR TITLE
Changed @import statement for @use

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Media Queries SCSS Mixins based on Angular FlexLayout
 Download and include `media-queries.scss`.
 
 ```scss
-@import 'media-queries.scss';
+@use 'media-queries.scss' as *;
 ```
 
 ### Example


### PR DESCRIPTION
Hello.

As in the official documentation, the sass team discourages use @import statement, I thought that is better to have the repository readme up to date, so there's only that change. It's a minimal change that does not generate any compatibility problem.

https://sass-lang.com/documentation/at-rules/import
![image](https://user-images.githubusercontent.com/73044608/178082377-28b1ff67-ac71-45a0-87e4-30984ee53331.png)

